### PR TITLE
Pin twisted==15.0.0 since twisted 15.1.0 breaks unit tests

### DIFF
--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ with open(os.path.join(base_dir, "fido", "__about__.py")) as f:
     exec(f.read(), about)
 
 install_requires = [
-    'twisted >= 15.0.0',
+    # TODO: Unpin twisted when https://twistedmatrix.com/trac/ticket/7888 is
+    #       fixed. Specifically, twisted 15.1.0 causes the test_fetch_body
+    #       unit test to fail.
+    'twisted == 15.0.0',
     'crochet',
     'service_identity',
     'pyOpenSSL',


### PR DESCRIPTION
```
spatel@devvm-spatel-yelpmain:~/git/fido-analogue (fix_flaky_tests) $ tox -e py --develop
py develop-inst-nodeps: /nail/home/spatel/git/fido-analogue
py runtests: commands[0] | py.test tests
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.6.7 -- py-1.4.27 -- pytest-2.7.0
rootdir: /nail/home/spatel/git/fido-analogue, inifile: 
collected 19 items 

tests/fido_test.py ...................

=========================================================== 19 passed in 12.14 seconds ============================================================
py runtests: commands[1] | flake8 .
_____________________________________________________________________ summary _____________________________________________________________________
  py: commands succeeded
  congratulations :)
```
