### PR TITLE
Fix Content-Length header to be a string - broke under twisted 15.1.0

### DIFF
--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -172,7 +172,7 @@ def fetch(url, timeout=DEFAULT_TIMEOUT, method='GET',
     if 'Content-Type' not in headers:
         headers['Content-Type'] = [content_type]
     if 'Content-Length' not in headers and body:
-        headers['Content-Length'] = [len(body)]
+        headers['Content-Length'] = [str(len(body))]
 
     crochet.setup()
     future = concurrent.futures.Future()

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ with open(os.path.join(base_dir, "fido", "__about__.py")) as f:
     exec(f.read(), about)
 
 install_requires = [
-    # TODO: Unpin twisted when https://twistedmatrix.com/trac/ticket/7888 is
-    #       fixed. Specifically, twisted 15.1.0 causes the test_fetch_body
-    #       unit test to fail.
-    'twisted == 15.0.0',
+    'twisted >= 15.0.0',
     'crochet',
     'service_identity',
     'pyOpenSSL',


### PR DESCRIPTION
Proper fix for compatiblity with twisted 15.1.0.  Header values should always be a string. This just happened to work under twisted 15.0.0.
