### PR TITLE
Don't schedule a cancel of the timer when the timeout is None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.0.1 (2015-XX-XX)
+---------------------
+- Don't schedule a timer cancelation when the timeout is None
+
 2.0.0 (2015-07-29)
 ---------------------
 - Default timeout in fido.fetch(..) has changed from 1s to None (wait indefinitely).

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -103,13 +103,14 @@ def fetch_inner(url, method, headers, body, future, timeout, connect_timeout):
     deferred.addCallback(response_callback)
     deferred.addErrback(finished.errback)
 
-    # Cancel the request if we hit the timeout
-    def cancel_timer(response):
-        if timer.active():
-            timer.cancel()
-        return response
-    timer = reactor.callLater(timeout, deferred.cancel)
-    finished.addBoth(cancel_timer)
+    if timeout is not None:
+        # Cancel the request if we hit the timeout
+        def cancel_timer(response):
+            if timer.active():
+                timer.cancel()
+            return response
+        timer = reactor.callLater(timeout, deferred.cancel)
+        finished.addBoth(cancel_timer)
 
     return finished
 


### PR DESCRIPTION
Fixes this assertion failure when calling `result(..)` without a timeout.  I couldn't find a reasonable way to test this since the `finished` from `fetch_inner` is not reachable via the public interface.

``` python
CRITICAL:twisted:Unhandled error in EventualResult
Traceback (most recent call last):
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/twisted/internet/base.py", line 1194, in run
    self.mainLoop()
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/twisted/internet/base.py", line 1203, in mainLoop
    self.runUntilCurrent()
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/twisted/internet/base.py", line 798, in runUntilCurrent
    f(*a, **kw)
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/crochet/_eventloop.py", line 416, in runs_in_reactor
    d = maybeDeferred(function, *args, **kwargs)
--- <exception caught here> ---
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/twisted/internet/defer.py", line 150, in maybeDeferred
    result = f(*args, **kw)
  File "/nail/home/spatel/git/fido-analogue/fido/fido.py", line 112, in fetch_inner
    timer = reactor.callLater(timeout, deferred.cancel)
  File "/nail/home/spatel/git/fido-analogue/.tox/py/lib/python2.6/site-packages/twisted/internet/base.py", line 708, in callLater
    "%s is not greater than or equal to 0 seconds" % (_seconds,)
_pytest.assertion.reinterpret.AssertionError: None is not greater than or equal to 0 seconds
```
