### PR TITLE
Add finish_timestamp to response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.1.3 (2015-10-05)
+---------------------
+- Add `finish_timestamp` as an attribute of the response
+
 2.1.2 (2015-08-10)
 ---------------------
 - Fix issue where errors from a request aren't getting raised.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"


### PR DESCRIPTION
`finish_timestamp` is needed to determine when exactly the response completed.
