### PR TITLE
Require twisted < 15.5.0 since python 2.6 support was dropped

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.1.1
+---------------------
+- Require twisted < 15.5.0 since Python 2.6 support was dropped
+
 2.1.0 (2015-08-06)
 ---------------------
 - Add reason to fido.Response

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(base_dir, "fido", "__about__.py")) as f:
     exec(f.read(), about)
 
 install_requires = [
-    'twisted >= 15.0.0',
+    'twisted >= 15.0.0, < 15.5.0',  # Python 2.6 support was dropped in 15.5.0
     'crochet',
     'service_identity',
     'pyOpenSSL',


### PR DESCRIPTION
Fix breaking builds
