### PR TITLE
Remove content-length when using FileBodyProducer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ MANIFEST
 fido.egg-info
 .coverage
 docs/build
+.cache/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.1.3 (2016-04-13)
+---------------------
+- Remove content-length when using FileBodyProducer
+
 2.1.2 (2015-08-10)
 ---------------------
 - Fix issue where errors from a request aren't getting raised.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -99,7 +99,7 @@ def fetch_inner(url, method, headers, body, future, timeout, connect_timeout):
         headers = dict(
             (key, value)
             for (key, value) in headers.iteritems()
-            if key != 'Content-Length' and key != 'content-length'
+            if key.lower() != 'content-length'
         )
 
     deferred = get_agent(reactor, connect_timeout).request(

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -96,8 +96,11 @@ def fetch_inner(url, method, headers, body, future, timeout, connect_timeout):
         # causing content-length to lose meaning and break the client.
         # FileBodyProducer will take care of re-computing length and re-adding
         # a new content-length header later.
-        headers.pop('Content-Length', None)
-        headers.pop('content-length', None)
+        headers = dict(
+            (key, value)
+            for (key, value) in headers.iteritems()
+            if key != 'Content-Length' and key != 'content-length'
+        )
 
     deferred = get_agent(reactor, connect_timeout).request(
         method=method,

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -91,6 +91,13 @@ def fetch_inner(url, method, headers, body, future, timeout, connect_timeout):
     bodyProducer = None
     if body:
         bodyProducer = FileBodyProducer(StringIO(body))
+        # content-length needs to be removed because it was computed based on
+        # body but body is now being processed by twisted FileBodyProducer
+        # causing content-length to lose meaning and break the client.
+        # FileBodyProducer will take care of re-computing length and re-adding
+        # a new content-length header later.
+        headers.pop('Content-Length', None)
+        headers.pop('content-length', None)
 
     deferred = get_agent(reactor, connect_timeout).request(
         method=method,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(base_dir, "fido", "__about__.py")) as f:
     exec(f.read(), about)
 
 install_requires = [
-    'twisted >= 15.0.0',
+    'twisted >= 15.0.0, < 15.5.0',  # Python 2.6 support was dropped in 15.5.0
     'crochet',
     'service_identity',
     'pyOpenSSL',

--- a/tests/fido_test.py
+++ b/tests/fido_test.py
@@ -134,6 +134,24 @@ def test_content_length_readded_by_twisted(server_url):
     assert actual_headers.get('content-length') == '22'
 
 
+def test_fetch_inner_headers_not_modified_in_place(server_url):
+    headers = {'foo': 'bar', 'Content-Length': '22'}
+    body = '{"some_json_data": 30}'
+    with mock.patch.object(fido.fido, 'get_agent'):
+        with mock.patch.object(fido.fido, 'crochet'):
+            fido.fido.fetch_inner(
+                server_url,
+                method='GET',
+                headers=headers,
+                body=body,
+                future=mock.Mock(),
+                timeout=None,
+                connect_timeout=None,
+            )
+
+    assert headers == {'foo': 'bar', 'Content-Length': '22'}
+
+
 def test_fetch_content_type(server_url):
     expected_content_type = 'text/html'
     future = fido.fetch(server_url, content_type=expected_content_type)


### PR DESCRIPTION
This issue was breaking requests (BadRequest error) when using the client on a real-world scenario.
I acceptance-tested the change with our internal framework.
