### PR TITLE
Fix critical unhandled error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.0.0 (2016-04-27)
+---------------------
+- Fido twisted client redesigned by the book (Twisted Network Programming Essentials).
+- Fix CRITICAL :: twisted - Unhandled error in Deferred.
+- Fix use of crochet library handling the reactor thread (@run_in_reactor and EventualResult).
+- Drop concurrent.futures in favor of crochet EventualResult.
+- Improved handling of timeout errors and exceptions in reactor thread.
+- Increased test coverage and documentation.
+
 2.1.4 (2016-04-18)
 ---------------------
 - Don't unnecessarily constrain the version of twisted when not using python 2.6.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "2.1.4"
+__version__ = "3.0.0"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/tests/acceptance/headers_test.py
+++ b/tests/acceptance/headers_test.py
@@ -4,4 +4,4 @@ from fido import fetch
 def test_fido_request_throws_no_timeout_when_header_value_not_list():
     fetch('http://www.yelp.com', headers={'Accept-Charset': 'utf-8',
                                           'Accept-Language': ['en-US']
-                                          }).result(timeout=5)
+                                          }).wait(timeout=5)


### PR DESCRIPTION
After having had an interest read from [Twisted Programming Essentials](http://www.amazon.com/Twisted-Network-Programming-Essentials-McKellar-ebook/dp/B00BT0IEJE/ref=sr_1_1?ie=UTF8&qid=1460649331&sr=8-1&keywords=twisted+programming+essentials) I got an idea about what could be the cause for issue #27.

**Possible causes**
1. First, the way we are catching exceptions might be problematic. [Here](https://github.com/Yelp/fido/blob/master/fido/fido.py#L81) we should at least return the failure or raise the exception, but we are only setting the future's error. The book states: 
   
   > If a callback or errback at level N doesn’t raise an Exception or return a Failure, control is passed to the callback at level N + 1. Note that this applies to errbacks! If an errback doesn’t produce an error, control passes to the callback chain. Control will criss-cross between the errback and callback chains depending on the results of processing the event."
2. Secondly, [this](https://github.com/Yelp/fido/pull/18/commits/488149342a512027bbf84ea7ad4088cd5b4faad4) is stated as a "please don't do" in [crochet documentation](https://crochet.readthedocs.org/en/1.4.0/api.html#run-in-reactor-asynchronous-results) as Twisted APIs are not thread safe and should not be called if not in the Twisted reactor thread. I believe we should put back the `@run_in_reactor` decorator at all costs.
   
   > Twisted’s APIs are not thread-safe, and so they cannot be called directly from another thread. Moreover, results may not be available immediately. The easiest way to deal with these issues is to decorate a function that calls Twisted APIs with crochet.wait_for. [...] wait_for is implemented using run_in_reactor, a more sophisticated and lower-level API.

**Solution**

I am proposing here a way simpler solution (literally by the [book](http://www.amazon.com/Twisted-Network-Programming-Essentials-McKellar-ebook/dp/B00BT0IEJE/ref=sr_1_1?ie=UTF8&qid=1460649331&sr=8-1&keywords=twisted+programming+essentials), chapter "Web Clients - Agent") which solves the issue of CRITICAL errors #27 and seems to work properly with our internal system. The general idea is that there is no need for futures as the EventualResult object from crochet already acts as some sort of future. Hence there's no need to set results/exceptions in the future ourselves, as the EventualResult does it already flawlessly and without risk of losing 'unhandled exceptions' as it was happening. 

**Testing**

Finally, I tested this client with our services and our acceptance suite was all green.
