### PR TITLE
Removing default json content type which is breaking servers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+3.1.0 (2016-05-13)
+---------------------
+- Don't send content-type='application/json' by default anymore.
+
 3.0.0 (2016-04-27)
 ---------------------
 - Fido twisted client redesigned by the book (Twisted Network Programming Essentials).

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/tests/fido_test.py
+++ b/tests/fido_test.py
@@ -232,7 +232,7 @@ def test_fetch_content_type(server_url):
     expected_content_type = 'text/html'
     eventual_result = fido.fetch(
         server_url,
-        content_type=expected_content_type
+        headers={'Content-Type': expected_content_type}
     )
     actual_content_type = eventual_result.wait().json()['headers'].\
         get('content-type')


### PR DESCRIPTION
Removing the default  content-type='application/json' as it was breaking the server on GET requests.

According to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1):

> Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body. If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream".

which means the content type SHOULD be used if there's a body but I am pretty sure it is not expected on GET requests and fido is now always adding it (also for GET requests).

Fido is mostly used from Yelp/bravado which now uses python `requests` to build the headers and the body, so everything (including content-type) should be taken care of on that side.
