### PR TITLE
Fido daemonization-safe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+3.2.1 (2016-06-16)
+---------------------
+- Fido is daemonization-safe with a solution similar to the one on crochet (reactor is not initialized at fido import time, see https://github.com/itamarst/crochet/issues/45). Forking is still discouraged.
+
 3.2.0 (2016-05-20)
 ---------------------
 - Fido is python 3 ready.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/fido/common.py
+++ b/fido/common.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import six
 from twisted.web.http_headers import Headers
 from yelp_bytes import to_bytes

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'service_identity',
         'six',
         'pyOpenSSL',
+        'psutil',
         'yelp_bytes',
     ],
     extras_require={

--- a/tests/0_import_reactor_test.py
+++ b/tests/0_import_reactor_test.py
@@ -8,7 +8,8 @@ explicitly import reactor (initializing it), we must run this file as first.
 import sys
 
 import psutil
-import subprocess
+from subprocess import PIPE
+from subprocess import Popen
 
 
 class TestTwistedReactorNotInitImportTime(object):
@@ -26,8 +27,9 @@ class TestTwistedReactorNotInitImportTime(object):
         pipes = 0
 
         pid = psutil.Process().pid
-        lsof_output = subprocess.check_output(['lsof', '-p', str(pid)])
-        lsof_lines = lsof_output.strip().split('\n')
+        subproc = Popen(['lsof', '-p', str(pid)], stdout=PIPE)
+        lsof_lines = subproc.communicate()[0].decode().split('\n')
+
         for line in lsof_lines:
             if 'PIPE' in line:
                 pipes = pipes + 1
@@ -45,8 +47,8 @@ class TestTwistedReactorNotInitImportTime(object):
         assert 'twisted.internet.reactor' not in sys.modules
         pipes_before = self.count_pipes()
 
-        import fido
-        from fido.fido import fetch
+        import fido  # noqa
+        from fido.fido import fetch  # noqa
 
         assert 'twisted.internet.reactor' not in sys.modules
         assert self.count_pipes() == pipes_before

--- a/tests/0_import_reactor_test.py
+++ b/tests/0_import_reactor_test.py
@@ -5,16 +5,17 @@ This test file should be run as first because it tests that twisted reactor
 is not initialized at fido import time. Since some other tests later will
 explicitly import reactor (initializing it), we must run this file as first.
 """
+import psutil
 import sys
 
-import psutil
 from subprocess import PIPE
 from subprocess import Popen
 
 
 class TestTwistedReactorNotInitImportTime(object):
     """
-    This class is trying to test that fido is (and stays) fork-safe.
+    This class is trying to test that fido is (and stays) daemonization-safe.
+    Fido is still not fork safe and forking is discouraged.
     """
 
     @staticmethod

--- a/tests/0_import_reactor_test.py
+++ b/tests/0_import_reactor_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import sys
+
+import psutil
+
+
+class TestTwistedReactorNotInitImportTime(object):
+    """
+    This class is trying to test that fido is (and stays) fork-safe.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.current_process = psutil.Process()
+        # get the number of file descriptors open before the test class is run
+        cls.pre_import_num_fds = cls.current_process.num_fds()
+
+    @classmethod
+    def _no_new_fds_open_after_swaggerpy_bravado_import(cls):
+        """
+        This test only checks for symptoms that something went wrong. If
+        twisted.reactor was initialized in any of the previous tests then the
+        number of file descriptors for the current process should be higher.
+        It seems that reactor opens up 3 file descriptors.
+        """
+
+        post_import_num_fds = cls.current_process.num_fds()
+        return cls.pre_import_num_fds >= post_import_num_fds - 2
+
+    def test_twisted_reactor_not_imported_after_fetch_import(self):
+        """
+        Test that reactor is not imported (and initialized) as a result of
+        importing fido modules and methods.
+        """
+
+        assert 'twisted.internet.reactor' not in sys.modules
+
+        import fido
+        from fido.fido import fetch
+
+        assert 'twisted.internet.reactor' not in sys.modules

--- a/tests/acceptance/headers_test.py
+++ b/tests/acceptance/headers_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from fido import fetch
 
 


### PR DESCRIPTION
Inizializing reactor at import time creates problems in the context of [daemonization](https://github.com/itamarst/crochet/issues/45).

I am trying to make sure that fido does not initialize reactor at import time (hence avoiding creation of additional pipes for eventpoll which could lead to 'Bad File Descriptor' exceptions).

I am aware that Twisted does not interact well with external ways of forking/spawning/daemonization, see ([stackoverflow here](http://stackoverflow.com/questions/19258972/listening-twisted-tcp-connection-with-python-daemon-gives-bad-file-descriptor/19260155#19260155)) so my personal suggestion would be to avoid using Fido if daemonization is in play.

Solves #30 

reviewers: @laucia @sjaensch
