### PR TITLE
Remove default index server from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist = py26,py27,py34
-indexserver =
-    default = https://pypi.python.org/simple/
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
We stumbled upon the problem of not being able to specify a different pypi index server during tests because tox was configured to use the org one as default.
Removing default index server from tox.ini to allow specifying another

@sjaensch primary
