### PR TITLE
Adding Fido custom exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+4.0.0 (2016-07-08)
+---------------------
+- Refactoring exceptions to distinguish between Connection errors and HTTP request/response errors.
+
 3.2.1 (2016-06-16)
 ---------------------
 - Fido is daemonization-safe with a solution similar to the one on crochet (reactor is not initialized at fido import time, see https://github.com/itamarst/crochet/issues/45). Forking is still discouraged.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "3.2.1"
+__version__ = "4.0.0"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/fido/exceptions.py
+++ b/fido/exceptions.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+
+class BaseTimeoutError(Exception):
+    """
+    Base class for all errors due to timeouts.
+    """
+
+
+class ConnectTimeoutError(BaseTimeoutError):
+    """
+    Connection took too long to establish
+    """
+
+
+class HTTPTimeoutError(BaseTimeoutError):
+    """
+    Server took too long to send the response.
+    """

--- a/fido/exceptions.py
+++ b/fido/exceptions.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 
 
-class ConnectionError(Exception):
+class NetworkError(Exception):
     """
     Base class for all errors due to connection problems (connection failing
     for any reason, including timeout reasons).
     """
 
 
-class TCPConnectError(ConnectionError):
+class TCPConnectionError(NetworkError):
     """
     A connection error occurred for some reasons.
     A common reason is the connection took too long to establish.
     """
 
 
-class HTTPTimeoutError(ConnectionError):
+class HTTPTimeoutError(NetworkError):
     """
     HTTP response was never received.
     A common reason is the server took too long to respond.

--- a/fido/exceptions.py
+++ b/fido/exceptions.py
@@ -1,19 +1,22 @@
 # -*- coding: utf-8 -*-
 
 
-class BaseTimeoutError(Exception):
+class ConnectionError(Exception):
     """
-    Base class for all errors due to timeouts.
-    """
-
-
-class ConnectTimeoutError(BaseTimeoutError):
-    """
-    Connection took too long to establish
+    Base class for all errors due to connection problems (connection failing
+    for any reason, including timeout reasons).
     """
 
 
-class HTTPTimeoutError(BaseTimeoutError):
+class TCPConnectError(ConnectionError):
     """
-    Server took too long to send the response.
+    A connection error occurred for some reasons.
+    A common reason is the connection took too long to establish.
+    """
+
+
+class HTTPTimeoutError(ConnectionError):
+    """
+    HTTP response was never received.
+    A common reason is the server took too long to respond.
     """

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -10,7 +10,7 @@ from six.moves.urllib_parse import urlparse
 from twisted.internet.defer import CancelledError
 from twisted.internet.defer import Deferred
 from twisted.internet.endpoints import TCP4ClientEndpoint
-from twisted.internet.error import TimeoutError as TwistedTimeoutError
+from twisted.internet.error import ConnectError as TwistedConnectError
 from twisted.internet.protocol import Protocol
 from yelp_bytes import to_bytes
 
@@ -223,7 +223,7 @@ def fetch_inner(url, method, headers, body, timeout, connect_timeout):
                     "send the response".format(timeout=timeout)
                 )
 
-        elif error.check(TwistedTimeoutError):
+        elif error.check(TwistedConnectError):
             raise ConnectTimeoutError(
                 "Connection was closed by Twisted Agent because the HTTP "
                 "connection took more than connect_timeout={connect_timeout} "

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -7,7 +7,6 @@ import os
 import crochet
 import six
 from six.moves.urllib_parse import urlparse
-from twisted.internet.defer import CancelledError
 from twisted.internet.defer import Deferred
 from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.internet.error import ConnectError as TwistedConnectError
@@ -16,7 +15,7 @@ from yelp_bytes import to_bytes
 
 from . import __about__
 from .common import listify_headers
-from fido.exceptions import ConnectTimeoutError
+from fido.exceptions import TCPConnectError
 from fido.exceptions import HTTPTimeoutError
 
 
@@ -216,15 +215,14 @@ def fetch_inner(url, method, headers, body, timeout, connect_timeout):
         """
 
         if error.check(_twisted_web_client().ResponseNeverReceived):
-            if error.value.reasons[0].check(CancelledError):
-                raise HTTPTimeoutError(
-                    "Connection was closed by fido because the server took "
-                    "more than timeout={timeout} seconds to "
-                    "send the response".format(timeout=timeout)
-                )
+            raise HTTPTimeoutError(
+                "Connection was closed by fido because the server took "
+                "more than timeout={timeout} seconds to "
+                "send the response".format(timeout=timeout)
+            )
 
         elif error.check(TwistedConnectError):
-            raise ConnectTimeoutError(
+            raise TCPConnectError(
                 "Connection was closed by Twisted Agent because the HTTP "
                 "connection took more than connect_timeout={connect_timeout} "
                 "seconds to establish.".format(connect_timeout=connect_timeout)

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -16,6 +16,8 @@ from yelp_bytes import to_bytes
 
 from . import __about__
 from .common import listify_headers
+from fido.exceptions import ConnectTimeoutError
+from fido.exceptions import HTTPTimeoutError
 
 
 ##############################################################################
@@ -25,7 +27,6 @@ from .common import listify_headers
 # If the fds are closed after the process daemonizes this could cause problems
 # ('Bad File Descriptor' exceptions).
 ##############################################################################
-
 
 def _import_reactor():
     from twisted.internet import reactor
@@ -216,14 +217,14 @@ def fetch_inner(url, method, headers, body, timeout, connect_timeout):
 
         if error.check(_twisted_web_client().ResponseNeverReceived):
             if error.value.reasons[0].check(CancelledError):
-                raise crochet.TimeoutError(
+                raise HTTPTimeoutError(
                     "Connection was closed by fido because the server took "
                     "more than timeout={timeout} seconds to "
                     "send the response".format(timeout=timeout)
                 )
 
         elif error.check(TwistedTimeoutError):
-            raise crochet.TimeoutError(
+            raise ConnectTimeoutError(
                 "Connection was closed by Twisted Agent because the HTTP "
                 "connection took more than connect_timeout={connect_timeout} "
                 "seconds to establish.".format(connect_timeout=connect_timeout)

--- a/tests/fido_test.py
+++ b/tests/fido_test.py
@@ -16,7 +16,7 @@ from fido.fido import _build_body_producer
 from fido.fido import _set_deferred_timeout
 from fido.fido import _twisted_web_client
 from fido.fido import DEFAULT_USER_AGENT
-from fido.exceptions import TCPConnectError
+from fido.exceptions import TCPConnectionError
 from fido.exceptions import HTTPTimeoutError
 
 SERVER_OVERHEAD_TIME = 2.0
@@ -175,13 +175,14 @@ def test_agent_connect_timeout():
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(TCPConnectError) as e:
+    with pytest.raises(TCPConnectionError) as e:
         eventual_result.wait()
 
     assert (
-        "Connection was closed by Twisted Agent because the HTTP "
-        "connection took more than connect_timeout={connect_timeout} seconds "
-        "to establish.".format(connect_timeout=TIMEOUT_TEST)
+        "Connection was closed by Twisted Agent because there was "
+        "a problem establishing the connection or the "
+        "connect_timeout={connect_timeout} was reached."
+        .format(connect_timeout=TIMEOUT_TEST)
         in str(e)
     )
 

--- a/tests/fido_test.py
+++ b/tests/fido_test.py
@@ -16,7 +16,7 @@ from fido.fido import _build_body_producer
 from fido.fido import _set_deferred_timeout
 from fido.fido import _twisted_web_client
 from fido.fido import DEFAULT_USER_AGENT
-from fido.exceptions import ConnectTimeoutError
+from fido.exceptions import TCPConnectError
 from fido.exceptions import HTTPTimeoutError
 
 SERVER_OVERHEAD_TIME = 2.0
@@ -175,7 +175,7 @@ def test_agent_connect_timeout():
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(ConnectTimeoutError) as e:
+    with pytest.raises(TCPConnectError) as e:
         eventual_result.wait()
 
     assert (

--- a/tests/fido_test.py
+++ b/tests/fido_test.py
@@ -16,6 +16,8 @@ from fido.fido import _build_body_producer
 from fido.fido import _set_deferred_timeout
 from fido.fido import _twisted_web_client
 from fido.fido import DEFAULT_USER_AGENT
+from fido.exceptions import ConnectTimeoutError
+from fido.exceptions import HTTPTimeoutError
 
 SERVER_OVERHEAD_TIME = 2.0
 TIMEOUT_TEST = 1.0
@@ -144,7 +146,7 @@ def test_agent_timeout(server_url):
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(crochet.TimeoutError) as e:
+    with pytest.raises(HTTPTimeoutError) as e:
         eventual_result.wait()
 
     assert (
@@ -173,7 +175,7 @@ def test_agent_connect_timeout():
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(crochet.TimeoutError) as e:
+    with pytest.raises(ConnectTimeoutError) as e:
         eventual_result.wait()
 
     assert (


### PR DESCRIPTION
I am refactoring the Fido Timeout exceptions to forward more information (timeout reason) uphill.
Currently, we have no way to understand which kind of timeout occurred (HTTP request/response or connection timeout?) as all of them are re-raised as a crochet.TimeoutError. 

Distinguishing between timeouts is needed to implement advanced retrying mechanisms.

An alternative could be to re-raise twisted underlying exceptions but this would require services to import and have knowledge of Twisted API (with all the reactor-related problems following the import of Twisted code).
Plus in this PR I am introducing a way to group them as a BaseTimeoutError so for cases when we only want to generally catch any timeout, there is no need to selectively import sub-exceptions or Twisted low-level exceptions. 
