### PR TITLE
Do not throw HTTPTimeoutError unless it was caused by CancelledError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+4.0.1 (2016-07-18)
+---------------------
+- Throw HTTPTimeoutError only if it was caused by CancelledError (bugfix).
+
 4.0.0 (2016-07-08)
 ---------------------
 - Refactoring exceptions to distinguish between Connection errors and HTTP request/response errors.

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -7,6 +7,7 @@ import os
 import crochet
 import six
 from six.moves.urllib_parse import urlparse
+from twisted.internet.defer import CancelledError
 from twisted.internet.defer import Deferred
 from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.internet.error import ConnectError
@@ -216,11 +217,12 @@ def fetch_inner(url, method, headers, body, timeout, connect_timeout):
         """
 
         if error.check(_twisted_web_client().ResponseNeverReceived):
-            raise HTTPTimeoutError(
-                "Connection was closed by fido because the server took "
-                "more than timeout={timeout} seconds to "
-                "send the response".format(timeout=timeout)
-            )
+            if error.value.reasons[0].check(CancelledError):
+                raise HTTPTimeoutError(
+                    "Connection was closed by fido because the server took "
+                    "more than timeout={timeout} seconds to "
+                    "send the response".format(timeout=timeout)
+                )
 
         elif error.check(ConnectError):
             raise TCPConnectionError(


### PR DESCRIPTION
Using HTTPTimeoutError is confusing if the error was not caused by a timeout, as it swallows the original error.

For example, on Fido 3.2, an SSL validation error gives this:
`twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure OpenSSL.SSL.Error: [('SSL routines', 'SSL3_GET_SERVER_CERTIFICATE', 'certificate verify failed')]>]`

But on Fido 4.0, an SSL validation errror will throw the following inaccurate error:
`fido.exceptions.HTTPTimeoutError: Connection was closed by fido because the server took more than timeout=None seconds to send the response`

I generated these exceptions with `fido.fetch('https://untrusted-root.badssl.com/').wait().body`
