### PR TITLE
Remove support for Python 2.6, bump version for v4.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py34
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+4.1.0 (2016-09-26)
+---------------------
+- Drop support for Python 2.6, fixing a build failure due to attrs not being Python 2.6 compatible anymore.
+
 4.0.1 (2016-07-18)
 ---------------------
 - Throw HTTPTimeoutError only if it was caused by CancelledError (bugfix).

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "4.0.1"
+__version__ = "4.1.0"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,8 @@ setup(
         'service_identity',
         'six',
         'pyOpenSSL',
+        'twisted >= 14.0.0',
         'yelp_bytes',
     ],
-    extras_require={
-        ':python_version!="2.6"': ['twisted >= 14.0.0'],
-        ':python_version=="2.6"': ['twisted >= 14.0.0, < 15.5'],
-    },
     license=about['__license__'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34
+envlist = py27,py34
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
twisted uses the attrs package, which dropped Python 2.6 support in version 16.0. Looks like they just added a Python 2.6 incompatibility, which is why our build (and that of bravado) fails. Rather than depending on an old version of attrs I decided to drop Python 2.6. It's not supported by the Python core team anymore.
