### PR TITLE
fix some documentation issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,9 @@ where there is no event loop, and where you cannot afford to spin up lots of thr
 
 Here is an example of using Fido::
 
-    future = fido.fetch('http://www.foo.bar')
+    future = fido.fetch('http://www.example.com')
     # Work happens in a background thread...
-    response = future.result(timeout=2)
+    response = future.wait(timeout=2)
     print(response.body)
 
 Frequently Asked Questions
@@ -54,7 +54,7 @@ the http proxy before starting your python process.
 Example::
 
     $ export http_proxy="http://localhost:8000"
-    $ python -c 'import fido; print(fido.fetch("http://www.yelp.com").result().body)'
+    $ python -c 'import fido; print(fido.fetch("http://www.example.com").wait().body)'
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,9 +16,9 @@ threads (otherwise you could just use a `ThreadPoolExecutor`_).
 
 Here is an example of using Fido::
 
-    future = fido.fetch('http://www.yelp.com')
+    future = fido.fetch('http://www.example.com')
     # Work happens in a background thread...
-    response = future.result(timeout=2)
+    response = future.wait(timeout=2)
     print response.body
 
 Frequently Asked Questions
@@ -51,7 +51,7 @@ the http proxy before starting your python process.
 Example::
 
     $ export http_proxy="http://localhost:8000"
-    $ python -c "import fido; print fido.fetch("http://www.yelp.com").result().body
+    $ python -c "import fido; print fido.fetch("http://www.example.com").wait().body
 
 
 API


### PR DESCRIPTION
* Fix docs to use `wait()` instead of `result()`, which doesn't exist.
* Also, use example.com, which is smaller and doesn't redirect