### PR TITLE
Make TLS support an extras_requires

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+4.2.0 (2016-09-26)
+------------------
+- Move TLS support into an extras so that the vast majority of users that are
+  not using TLS don't need to install extra dependencies. Note that if this
+  causes breakage for you change your dependency to fido[tls] and it should
+  be fine
+
 4.1.0 (2016-09-26)
 ---------------------
 - Drop support for Python 2.6, fixing a build failure due to attrs not being Python 2.6 compatible anymore.

--- a/README.rst
+++ b/README.rst
@@ -30,15 +30,23 @@ Here is an example of using Fido::
 Frequently Asked Questions
 ==========================
 
-Do you support SSL?
+Do you support TLS?
 -------------------
 
-Yes, although this has not been vetted by security professionals. One should use this functionality at their own risk. In more detail: Fido uses the Twisted defaults, which delegate to pyOpenSSL_ and `service_identity`_ for the actual SSL work.
+Yes, although this has not been vetted by security professionals.
+One should use this functionality at their own risk.
+In more detail: Fido uses the Twisted defaults, which delegate to
+pyOpenSSL_ and `service_identity`_ for the actual TLS work.
+
+Note that to get this you need to install the `tls` extra::
+
+    $ pip install --upgrade fido[tls]
 
 Is the API stable?
 ------------------
 
-Probably not.  However, it is currently very simple, so it shouldn't be hard to upgrade code if there's a non backwards-compatible change.
+Probably not.  However, it is currently very simple, so it shouldn't be hard
+to upgrade code if there's a non backwards-compatible change.
 
 Do I need to initialize `Crochet`_?
 -----------------------------------
@@ -64,6 +72,10 @@ Installation
 Fido can be installed using `pip install`, like so::
 
     $ pip install --upgrade fido
+
+If you want TLS capabilities::
+
+    $ pip install --upgrade fido[tls]
 
 License
 ========

--- a/fido/__about__.py
+++ b/fido/__about__.py
@@ -7,7 +7,7 @@ __title__ = "fido"
 __summary__ = "Intelligent asynchronous HTTP client"
 __uri__ = "https://github.com/Yelp/fido"
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ setup(
             # Bug in pip's resolution of extras of extras is broken
             # so we list twisted[tls] out manually
             # see https://github.com/pypa/pip/issues/988
-            'pyOpenSSL',
-            'service-identity'
+            'pyOpenSSL >= 16.0.0',
+            'service-identity',
+            'idna >= 0.6, != 2.3',
         ]
     },
     license=about['__license__'],

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,18 @@ setup(
     ],
     install_requires=[
         'crochet',
-        'service_identity',
         'six',
-        'pyOpenSSL',
         'twisted >= 14.0.0',
         'yelp_bytes',
     ],
+    extras_require={
+        'tls': [
+            # Bug in pip's resolution of extras of extras is broken
+            # so we list twisted[tls] out manually
+            # see https://github.com/pypa/pip/issues/988
+            'pyOpenSSL',
+            'service-identity'
+        ]
+    },
     license=about['__license__'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,10 @@ deps = {[testenv]deps}
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 
+[testenv:tls]
+commands =
+    pip install .[tls]
+    python -c 'import twisted.internet.ssl'
+
 [flake8]
 exclude = .tox,virtualenv_*,docs


### PR DESCRIPTION
This makes it so that the common case (non ssl use) does not need to
depend on pyopenssl, cryptography, etc ... These packages are fragile
and hard to build in general so not having it as a mandatory requirement
is a great idea.

Fixes #49 