### PR TITLE
Fixed issue #5 from yelp/fido

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -324,9 +324,10 @@ def fetch(
         EventualResult object as stated in the official documentation
 
     """
+
     logging.basicConfig(level=logging.DEBUG)
     logging.debug(u"%s %s(%r)" % (method, url, body))
-    
+
     # Twisted requires the method, url, headers to be bytes
     url = to_bytes(url)
     method = to_bytes(method)

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import io
 import json
 import os
+import logging
 
 import crochet
 import six
@@ -323,7 +324,9 @@ def fetch(
         EventualResult object as stated in the official documentation
 
     """
-
+    logging.basicConfig(level=logging.DEBUG)
+    logging.debug(u"%s %s(%r)" % (method, url, body))
+    
     # Twisted requires the method, url, headers to be bytes
     url = to_bytes(url)
     method = to_bytes(method)


### PR DESCRIPTION
Added debug logs during fetch. 

Hey guys, this is my first pull request ever. Hope the bit of code I provided was what you were looking for. If not, let me know and I'll see how I can fix it. 

Just one thing. The body of the request is always logged as an empty repr, (''), because fetch is always called without a body. If we wanted to log the body as well, then we would have to do the log from a function other than fetch. Hope that makes sense...