### PR TITLE
Make sure our timeout exception is compatible to crochet.TimeoutError

### DIFF
--- a/fido/exceptions.py
+++ b/fido/exceptions.py
@@ -20,6 +20,7 @@ class HTTPTimeoutError(NetworkError, crochet.TimeoutError):
     """
     HTTP response was never received.
     A common reason is the server took too long to respond.
-    We're also inheriting from `crochet.TimeoutError` so we're backwards compatible with
-    code that catches that exception (which is what we used to raise previously).
+    We're also inheriting from `crochet.TimeoutError` so we're backwards
+    compatible with code that catches that exception (which is what we used
+    to raise previously).
     """

--- a/fido/exceptions.py
+++ b/fido/exceptions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import crochet
 
 
 class NetworkError(Exception):
@@ -15,8 +16,10 @@ class TCPConnectionError(NetworkError):
     """
 
 
-class HTTPTimeoutError(NetworkError):
+class HTTPTimeoutError(NetworkError, crochet.TimeoutError):
     """
     HTTP response was never received.
     A common reason is the server took too long to respond.
+    We're also inheriting from `crochet.TimeoutError` so we're backwards compatible with
+    code that catches that exception (which is what we used to raise previously).
     """

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,0 +1,11 @@
+import crochet
+
+import fido.exceptions
+
+
+def test_timeout_error_is_compatible_crochet():
+    """Make sure the timeout exception we raise is compatible with old fido versions.
+    We used to raise a `crochet.TimeoutError`.
+    """
+    timeout_exc = fido.exceptions.HTTPTimeoutError()
+    assert isinstance(timeout_exc, crochet.TimeoutError)

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -4,8 +4,8 @@ import fido.exceptions
 
 
 def test_timeout_error_is_compatible_crochet():
-    """Make sure the timeout exception we raise is compatible with old fido versions.
-    We used to raise a `crochet.TimeoutError`.
+    """Make sure the timeout exception we raise is compatible with old fido
+    versions. We used to raise a `crochet.TimeoutError`.
     """
     timeout_exc = fido.exceptions.HTTPTimeoutError()
     assert isinstance(timeout_exc, crochet.TimeoutError)


### PR DESCRIPTION
A while ago we switched to throwing our own HTTPTimeoutErrors instead of the crochet.TimeoutError class. Unfortunately, we didn't make this change for when the timeout is passed as part of the result() call (which we can't easily do in fido). We did make that change in bravado though.

@bplotnick brought up the point that this can cause difficult to detect issues in production, as you typically won't notice the exception type change in tests. He suggested a major version bump (which is what we did when we introduced the HTTPTimeoutError exception).

Unfortunately this won't help in the case where people don't read the changelog and just assume things are working if the don't detect any obvious breakage. That's why I want to make a simple but hopefully really effective change: make HTTPTimeoutError a subclass of crochet.TimeoutError as well. This should be fully backwards compatible. We can then require a version of fido in bravado that has this improved HTTPTimeoutError class, making sure things continue to work as expected.