### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 
+python:
+  - "2.7"
+  - "3.4"
+
 env:
-  - TOXENV=py27
-  - TOXENV=py34
+  - TOXENV=py
 
 install:
   - pip install tox coveralls
@@ -13,5 +16,3 @@ script:
 after_success:
   - tox -e cover
   - coveralls
-
-sudo: false

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
         'crochet',
         'six',
-        'twisted >= 14.0.0',
         'yelp_bytes',
     ],
     extras_require={
@@ -44,7 +44,14 @@ setup(
             'pyOpenSSL >= 16.0.0',
             'service-identity',
             'idna >= 0.6, != 2.3',
-        ]
+        ],
+
+        # Defining twisted dependency here to allow twisted
+        # requirement constraint defined by python_version
+        '': ['twisted >= 14.0.0'],
+        # Twisted>=17 does support only python 2.7 and 3.5+
+        ':python_version=="3.3"': ['twisted < 17.0.0'],
+        ':python_version=="3.4"': ['twisted < 17.0.0'],
     },
     license=about['__license__'],
 )


### PR DESCRIPTION
The build of the package is broken because from April 16th, 2019 travis uses python 3.6 as default python version.
This causes:
 * python2.7 test failures because tests are actually executed on python3.6 (for which thread timeout does not look working properly)
 * python3.4 tests fails because the interpreter is not found

Fixing the travis configurations I've noticed that updates on twisted dependency made the latest versions not supporting python3.3 and python3.4.
In order to fix it I've updated the setup.py file in order to define a max twisted version for the specified versions.

NOTE: In a follow-up PR I'll try to address test failures on python3.5 and python3.6 by enabling the repo to test such versions