### PR TITLE
Support newer python 3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
 env:
   - TOXENV=py

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     install_requires=[
         'crochet',


### PR DESCRIPTION
The goal of this PR is to ensure that tests will succeed on more recent python3 versions.

By running the tests (specifically the acceptance tests) on Python 3.5+ I was noticing that tests were not completing because of some weird interactions with `httpd.server_close()` or `httpd_thread.join()`.
As the code was used only for testing I've opted to open a new process serving the HTTP service instead of running it within a separate thread.
Doing this makes the tests green and so we can also update the package classifiers announcing that we fully support more recent python versions than 3.4 only.

NOTE: At Yelp we were already using `fido` on 3.5 and 3.6 from some time without major issues ;)