### PR TITLE
Update pytest.raises exception info usage (changed with pytest>=5)

### DIFF
--- a/tests/acceptance/fetch_test.py
+++ b/tests/acceptance/fetch_test.py
@@ -170,14 +170,14 @@ def test_agent_timeout(server_url, tcp_nodelay):
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(HTTPTimeoutError) as e:
+    with pytest.raises(HTTPTimeoutError) as excinfo:
         eventual_result.wait(timeout=1)
 
     assert (
         "Connection was closed by fido because the server took "
         "more than timeout={timeout} seconds to "
         "send the response".format(timeout=TIMEOUT_TEST)
-        in str(e)
+        in str(excinfo.value)
     )
 
 
@@ -200,7 +200,7 @@ def test_agent_connect_timeout(tcp_nodelay):
     # EventualResult stores them and re-raises on result retrieval
     assert eventual_result.original_failure() is not None
 
-    with pytest.raises(TCPConnectionError) as e:
+    with pytest.raises(TCPConnectionError) as excinfo:
         eventual_result.wait(timeout=1)
 
     assert (
@@ -208,7 +208,7 @@ def test_agent_connect_timeout(tcp_nodelay):
         "a problem establishing the connection or the "
         "connect_timeout={connect_timeout} was reached."
         .format(connect_timeout=TIMEOUT_TEST)
-        in str(e)
+        in str(excinfo.value)
     )
 
 


### PR DESCRIPTION
Tests are failing on Jenkins (Yelp internal builds) with the following traceback
```
tests/acceptance/fetch_test.py ..FF........FF..........                  [100%]

=================================== FAILURES ===================================
__________________________ test_agent_timeout[False] ___________________________

server_url = 'http://127.0.0.1:41141', tcp_nodelay = False

    def test_agent_timeout(server_url, tcp_nodelay):
        """
        Testing that we don't wait forever on the server sending back a response
        """
    
        eventual_result = fido.fetch(
            server_url + ECHO_URL + '/slow',
            timeout=TIMEOUT_TEST,
            tcp_nodelay=tcp_nodelay,
        )
    
        # wait for fido to estinguish the timeout and abort before test-assertions
        time.sleep(2 * TIMEOUT_TEST)
    
        # timeout errors were thrown and handled in the reactor thread.
        # EventualResult stores them and re-raises on result retrieval
        assert eventual_result.original_failure() is not None
    
        with pytest.raises(HTTPTimeoutError) as e:
            eventual_result.wait(timeout=1)
    
>       assert (
            "Connection was closed by fido because the server took "
            "more than timeout={timeout} seconds to "
            "send the response".format(timeout=TIMEOUT_TEST)
            in str(e)
        )
E       AssertionError: assert 'Connection was closed by fido because the server took more than timeout=1.0 seconds to send the response' in '<ExceptionInfo HTTPTimeoutError tblen=5>'
E        +  where 'Connection was closed by fido because the server took more than timeout=1.0 seconds to send the response' = <built-in method format of str object at 0x7fe5714a4b70>(timeout=1.0)
E        +    where <built-in method format of str object at 0x7fe5714a4b70> = 'Connection was closed by fido because the server took more than timeout={timeout} seconds to send the response'.format
E        +  and   '<ExceptionInfo HTTPTimeoutError tblen=5>' = str(<ExceptionInfo HTTPTimeoutError tblen=5>)
```

Python version: `3.6.0`
Installed dependencies: `atomicwrites==1.3.0,attrs==19.3.0,Automat==0.7.0,constantly==15.1.0,coverage==4.5.4,crochet==1.9.0,entrypoints==0.3,-e git+git@git.yelpcorp.com:mirrors/Yelp/fido@2464065c50d8e4e9c58f892dc04a9ecb3c7bb332#egg=fido,flake8==3.7.9,hyperlink==19.0.0,idna==2.8,importlib-metadata==1.3.0,incremental==17.5.0,mccabe==0.6.1,mock==3.0.5,more-itertools==8.0.2,packaging==19.2,pluggy==0.13.0,py==1.8.0,pycodestyle==2.5.0,pyflakes==2.1.1,PyHamcrest==1.9.0,pyparsing==2.4.2,pytest==5.2.1,six==1.13.0,Twisted==19.7.0,wcwidth==0.1.7,wrapt==1.11.2,yelp-bytes==0.3.0,yelp-encodings==0.1.3,zipp==0.6.0,zope.interface==4.6.0`

The breakage is caused by the direct usage of `str` method on a `ExceptionInfo` instance. This behaviour has changed on `pytest>=5` ([#5412 on pytest changelog](https://docs.pytest.org/en/latest/changelog.html#id125)], [pytest-dev/pytest#5413](https://github.com/pytest-dev/pytest/pull/5413/files))