### PR TITLE
Drop py3.4 build, add py3.7 build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py37
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Python 3.4 is EOL and py3.7 has a good bit of life ahead of it, while not being too new.